### PR TITLE
Setup code coverage on codecov.io with tarpaulin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: rust
+addons:
+  apt:
+    packages:
+      - libssl-dev
 rust:
   - stable
   - nightly
@@ -6,5 +10,11 @@ matrix:
   allow_failures:
     - rust: nightly
 cache: cargo
+after_success: |
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
+    cargo tarpaulin --out Xml
+    bash <(curl -s https://codecov.io/bash)
+  fi
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: rust
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Dynamic Wallpaper
 [![Build Status](https://travis-ci.com/mklein994/dynamic_wallpaper.svg?branch=master)](https://travis-ci.com/mklein994/dynamic_wallpaper)
+[![codecov](https://codecov.io/gh/mklein994/dynamic_wallpaper/branch/master/graph/badge.svg)](https://codecov.io/gh/mklein994/dynamic_wallpaper)
 
 Change your wallpaper depending on the time of day and the position of the sun.


### PR DESCRIPTION
`cargo-tarpaulin` is a crate for calculating code coverage.