### PR TITLE
Remove chrono_humanize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,14 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-humanize"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "dirs"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,7 +72,6 @@ name = "dynamic_wallpaper"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -395,7 +386,6 @@ dependencies = [
 "checksum cc 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "70f2a88c2e69ceee91c209d8ef25b81fc1a65f42c7f14dfd59d1fed189e514d1"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2ff48a655fe8d2dae9a39e66af7fd8ff32a879e8c4e27422c25596a8b5e90d"
 "checksum dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f679c09c1cf5428702cc10f6846c56e4e23420d3a88bcc9335b17c630a7b710b"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 chrono = { version = "0.4.4", features = ["serde"] }
-chrono-humanize = "0.0.11"
 dirs = "1.0.2"
 env_logger = "0.5.10"
 failure = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate chrono;
-extern crate chrono_humanize;
 extern crate dirs;
 extern crate env_logger;
 extern crate failure;
@@ -62,12 +61,6 @@ fn get_image(
     let (start, end) = sun.start_end(time_period);
     let duration = (end - start).num_nanoseconds().unwrap();
     let elapsed_time = (now - start).num_nanoseconds().unwrap();
-    debug!(
-        "elapsed time: {} ({:.2}%)",
-        format_duration(Duration::nanoseconds(elapsed_time)),
-        // calculate as a percent
-        elapsed_time as f64 * 100_f64 / duration as f64
-    );
 
     //  elapsed_time
     // ━━━━━━━━━━━━━━━
@@ -272,11 +265,6 @@ impl fmt::Display for TimePeriod {
             TimePeriod::DayTime => write!(f, "\u{1f3d9} Daytime"),
         }
     }
-}
-
-fn format_duration(duration: Duration) -> String {
-    use chrono_humanize::{Accuracy, HumanTime, Tense};
-    HumanTime::from(duration).to_text_en(Accuracy::Precise, Tense::Present)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This means that formatting durations isn't available, but also it
removes a dependency that was only there for debugging.