### PR TITLE
Add windows support to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: rust
+os:
+  - linux
+  - osx
+  - windows
 rust:
   - stable
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - stable
+  - beta
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+    - os: windows
 cache:
   directories:
     - /home/travis/.cargo


### PR DESCRIPTION
Include Windows in builds, now that Travis supports it: https://blog.travis-ci.com/2018-10-11-windows-early-release